### PR TITLE
[meta] update MSRV to Rust 1.67

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust-version: ["1.61", stable]
+        # 1.67 is the MSRV
+        rust-version: ["1.67", stable]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,18 @@ members = [
     "crates/*",
 ]
 
-# Ideally, we'd be able to use workspace dependencies, but that's only supported starting Rust 1.64,
-# and our MSRV is Rust 1.61.
+[workspace.package]
+rust-version = "1.67"
+
+[workspace.dependencies]
+dropshot = "0.10.0"
+expectorate = "1.0.6"
+newtype-uuid = { path = "crates/newtype-uuid" }
+prettyplease = "0.2.22"
+proptest = "1.5.0"
+schemars = "0.8.17"
+serde = "1"
+serde_json = "1.0.115"
+syn = "2.0.48"
+typify = "0.0.15"
+uuid = { version = "1.7.0", default-features = false }

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -6,15 +6,15 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-newtype-uuid = { version = "1.1.3", path = "../newtype-uuid" }
-dropshot = { version = "0.10.0", optional = true }
-expectorate = { version = "1.0.6", optional = true }
-prettyplease = { version = "0.2.22", optional = true }
-schemars = { version = "0.8.17", optional = true }
-serde = { version = "1", optional = true }
-serde_json = { version = "1.0.115", optional = true }
-syn = { version = "2.0.48", optional = true }
-typify = { version = "0.0.15", optional = true }
+newtype-uuid.workspace = true
+dropshot = { workspace = true, optional = true }
+expectorate = { workspace = true, optional = true }
+prettyplease = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+syn = { workspace = true, optional = true }
+typify = { workspace = true, optional = true }
 
 [features]
 internal-schemars08-tests = [

--- a/crates/newtype-uuid/Cargo.toml
+++ b/crates/newtype-uuid/Cargo.toml
@@ -9,8 +9,7 @@ documentation = "https://docs.rs/newtype-uuid"
 readme = "README.md"
 keywords = ["uuid", "unique", "guid", "newtype"]
 categories = ["data-structures", "no-std"]
-rust-version = "1.61"
-resolver = "2"
+rust-version.workspace = true
 exclude = [".cargo/**/*", ".github/**/*", "scripts/**/*"]
 
 [package.metadata.docs.rs]
@@ -18,10 +17,10 @@ all-features = true
 rustdoc-args = ["--cfg=doc_cfg"]
 
 [dependencies]
-proptest = { version = "1.5.0", optional = true }
-serde = { version = "1", optional = true, features = ["derive"] }
-schemars = { version = "0.8", features = ["uuid1"], optional = true }
-uuid = { version = "1.7.0", default-features = false }
+proptest = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+schemars = { workspace = true, features = ["uuid1"], optional = true }
+uuid.workspace = true
 
 [features]
 default = ["uuid/default", "std"]


### PR DESCRIPTION
Several dependent crates need this.
