### PR TITLE
Revert "[meta] update MSRV to 1.75 (#79)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # 1.75 is the MSRV
-        rust-version: ["1.75", stable]
+        # 1.67 is the MSRV
+        rust-version: ["1.67", stable]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidecomputer/newtype-uuid"
 documentation = "https://docs.rs/newtype-uuid"
-rust-version = "1.75"
+rust-version = "1.67"
 
 [workspace.dependencies]
 expectorate = "1.2.0"

--- a/crates/newtype-uuid/README.md
+++ b/crates/newtype-uuid/README.md
@@ -5,7 +5,7 @@
 ![License: MIT OR Apache-2.0](https://img.shields.io/crates/l/newtype-uuid.svg?)
 [![crates.io](https://img.shields.io/crates/v/newtype-uuid.svg?logo=rust)](https://crates.io/crates/newtype-uuid)
 [![docs.rs](https://img.shields.io/docsrs/newtype-uuid.svg?logo=docs.rs)](https://docs.rs/newtype-uuid)
-[![Rust: ^1.75.0](https://img.shields.io/badge/rust-^1.75.0-93450a.svg?logo=rust)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+[![Rust: ^1.67.0](https://img.shields.io/badge/rust-^1.67.0-93450a.svg?logo=rust)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 <!-- cargo-sync-rdme ]] -->
 <!-- cargo-sync-rdme rustdoc [[ -->
 A newtype wrapper around [`Uuid`](https://docs.rs/uuid/1.17.0/uuid/struct.Uuid.html).
@@ -111,7 +111,7 @@ permits conversions between typed and untyped UUIDs.
 
 ## Minimum supported Rust version (MSRV)
 
-The MSRV of this crate is **Rust 1.75.** In general, this crate will follow the MSRV of the
+The MSRV of this crate is **Rust 1.67.** In general, this crate will follow the MSRV of the
 underlying `uuid` crate or of dependencies, with an aim to be conservative.
 
 Within the 1.x series, MSRV updates will be accompanied by a minor version bump. The MSRVs for
@@ -120,7 +120,6 @@ each minor version are:
 * Version **1.0.x**: Rust 1.60.
 * Version **1.1.x**: Rust 1.61. This permits `TypedUuid<T>` to have `const fn` methods.
 * Version **1.2.x**: Rust 1.67, required by some dependency updates.
-* Unreleased: Rust 1.75, required by some dependency updates.
 
 ## Alternatives
 

--- a/crates/newtype-uuid/src/lib.rs
+++ b/crates/newtype-uuid/src/lib.rs
@@ -102,7 +102,7 @@
 //!
 //! # Minimum supported Rust version (MSRV)
 //!
-//! The MSRV of this crate is **Rust 1.75.** In general, this crate will follow the MSRV of the
+//! The MSRV of this crate is **Rust 1.67.** In general, this crate will follow the MSRV of the
 //! underlying `uuid` crate or of dependencies, with an aim to be conservative.
 //!
 //! Within the 1.x series, MSRV updates will be accompanied by a minor version bump. The MSRVs for
@@ -111,7 +111,6 @@
 //! * Version **1.0.x**: Rust 1.60.
 //! * Version **1.1.x**: Rust 1.61. This permits `TypedUuid<T>` to have `const fn` methods.
 //! * Version **1.2.x**: Rust 1.67, required by some dependency updates.
-//! * Unreleased: Rust 1.75, required by some dependency updates.
 //!
 //! # Alternatives
 //!


### PR DESCRIPTION
This reverts commit 48e9c57b1d34f85b323668fc43017228417baa5c.

We're going to bump the MSRV in the future, but let's lower it for now to avoid an unnecessary minor version bump.
