### PR TITLE
[1/n] bump MSRV to Rust 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # 1.79 is the MSRV
-        rust-version: ["1.79", stable]
+        # 1.85 is the MSRV
+        rust-version: ["1.85", stable]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*", "e2e-example/*"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/oxidecomputer/newtype-uuid"
-rust-version = "1.79"
+rust-version = "1.85"
 
 [workspace.dependencies]
 datatest-stable = "0.3.2"

--- a/crates/newtype-uuid-macros/README.md
+++ b/crates/newtype-uuid-macros/README.md
@@ -5,7 +5,7 @@
 ![License: MIT OR Apache-2.0](https://img.shields.io/crates/l/newtype-uuid-macros.svg?)
 [![crates.io](https://img.shields.io/crates/v/newtype-uuid-macros.svg?logo=rust)](https://crates.io/crates/newtype-uuid-macros)
 [![docs.rs](https://img.shields.io/docsrs/newtype-uuid-macros.svg?logo=docs.rs)](https://docs.rs/newtype-uuid-macros)
-[![Rust: ^1.79.0](https://img.shields.io/badge/rust-^1.79.0-93450a.svg?logo=rust)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+[![Rust: ^1.85.0](https://img.shields.io/badge/rust-^1.85.0-93450a.svg?logo=rust)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 <!-- cargo-sync-rdme ]] -->
 <!-- cargo-sync-rdme rustdoc [[ -->
 Procedural macro for [`newtype-uuid`](https://docs.rs/newtype-uuid).

--- a/crates/newtype-uuid/README.md
+++ b/crates/newtype-uuid/README.md
@@ -5,7 +5,7 @@
 ![License: MIT OR Apache-2.0](https://img.shields.io/crates/l/newtype-uuid.svg?)
 [![crates.io](https://img.shields.io/crates/v/newtype-uuid.svg?logo=rust)](https://crates.io/crates/newtype-uuid)
 [![docs.rs](https://img.shields.io/docsrs/newtype-uuid.svg?logo=docs.rs)](https://docs.rs/newtype-uuid)
-[![Rust: ^1.79.0](https://img.shields.io/badge/rust-^1.79.0-93450a.svg?logo=rust)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+[![Rust: ^1.85.0](https://img.shields.io/badge/rust-^1.85.0-93450a.svg?logo=rust)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 <!-- cargo-sync-rdme ]] -->
 <!-- cargo-sync-rdme rustdoc [[ -->
 A newtype wrapper around [`Uuid`](https://docs.rs/uuid/1.17.0/uuid/struct.Uuid.html).
@@ -129,7 +129,7 @@ permits conversions between typed and untyped UUIDs.
 
 ## Minimum supported Rust version (MSRV)
 
-The MSRV of this crate is **Rust 1.79.** In general, this crate will follow the MSRV of the
+The MSRV of this crate is **Rust 1.85.** In general, this crate will follow the MSRV of the
 underlying `uuid` crate or of dependencies, with an aim to be conservative.
 
 Within the 1.x series, MSRV updates will be accompanied by a minor version bump. The MSRVs for
@@ -139,6 +139,7 @@ each minor version are:
 * Version **1.1.x**: Rust 1.61. This permits `TypedUuid<T>` to have `const fn` methods.
 * Version **1.2.x**: Rust 1.67, required by some dependency updates.
 * Version **1.3.x**: Rust 1.79, required by some dependency updates.
+* Version **1.4.x**: Rust 1.85, required by some dependency updates.
 
 ## Alternatives
 

--- a/crates/newtype-uuid/src/lib.rs
+++ b/crates/newtype-uuid/src/lib.rs
@@ -122,7 +122,7 @@
 //!
 //! # Minimum supported Rust version (MSRV)
 //!
-//! The MSRV of this crate is **Rust 1.79.** In general, this crate will follow the MSRV of the
+//! The MSRV of this crate is **Rust 1.85.** In general, this crate will follow the MSRV of the
 //! underlying `uuid` crate or of dependencies, with an aim to be conservative.
 //!
 //! Within the 1.x series, MSRV updates will be accompanied by a minor version bump. The MSRVs for
@@ -132,6 +132,7 @@
 //! * Version **1.1.x**: Rust 1.61. This permits `TypedUuid<T>` to have `const fn` methods.
 //! * Version **1.2.x**: Rust 1.67, required by some dependency updates.
 //! * Version **1.3.x**: Rust 1.79, required by some dependency updates.
+//! * Version **1.4.x**: Rust 1.85, required by some dependency updates.
 //!
 //! # Alternatives
 //!


### PR DESCRIPTION
Updating to syn 3 requires serde_tokenstream 0.3, which is on Rust edition 2024 and so needs Rust 1.85.

Per the MSRV policy in the readme, this makes the next newtype-uuid release 1.4.0 rather than 1.3.3.
