### PR TITLE
[3/n] scope the MSRV CI job to published crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,19 @@ jobs:
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@nextest
-      - name: Build
+      - name: Build (stable)
+        if: matrix.rust-version == 'stable'
         run: just powerset build --all-targets
-      - name: Test
+      - name: Test (stable)
+        if: matrix.rust-version == 'stable'
         run: just powerset nextest run --all-targets --no-tests=pass -E 'not (test(ui) or test(snapshot))'
+      # (e2e-schema-consumer is excluded for the MSRV build -- see the Justfile.)
+      - name: Build (MSRV)
+        if: matrix.rust-version != 'stable'
+        run: just powerset-msrv build --all-targets
+      - name: Test (MSRV)
+        if: matrix.rust-version != 'stable'
+        run: just powerset-msrv nextest run --all-targets --no-tests=pass -E 'not (test(ui) or test(snapshot))'
       - name: Run extended tests (only on stable)
         if: matrix.rust-version == 'stable'
         run: cargo nextest run --all-targets --all-features

--- a/Justfile
+++ b/Justfile
@@ -15,6 +15,17 @@ powerset *args:
     excluded_features="{{excluded_features_default}}"
     NEXTEST_NO_TESTS=pass cargo hack --feature-powerset --workspace --exclude-features "${excluded_features// /,}" "$@"
 
+# Run `cargo hack --feature-powerset` on crates that build at the MSRV
+powerset-msrv *args:
+    #!/usr/bin/env bash
+
+    # e2e-schema-consumer depends on typify, whose regress dependency
+    # potentially needs a newer Rust than the MSRV. It isn't actually published,
+    # so it is only built on stable.
+    excluded_features="{{excluded_features_default}}"
+    NEXTEST_NO_TESTS=pass cargo hack --feature-powerset --workspace --exclude e2e-schema-consumer \
+        --exclude-features "${excluded_features// /,}" "$@"
+
 # Run `cargo hack` with no-std-compatible features
 powerset-no-std *args:
     #!/usr/bin/env bash


### PR DESCRIPTION
No reason to include the e2e schema stuff in it -- upcoming PRs will break the e2e example on the MSRV.
